### PR TITLE
Add authentication

### DIFF
--- a/controllers/README.md
+++ b/controllers/README.md
@@ -1,5 +1,0 @@
-# Controllers
-
-This folder is where you define your app routes and their logic.
-
-You can (and _should_) delete once you start developing your app.

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -1,0 +1,64 @@
+const router = require('express').Router()
+const bcrypt = require('bcryptjs')
+
+// Middleware & Helpers
+const { generateToken } = require("../helpers/jwt");
+const { checkToken, checkRole } = require("../middlewares/authorization");
+
+// Models
+const User = require('../models/db/user')
+
+router.route('/register')
+  .post(async (req, res) => {
+    const user = {
+      ...req.body,
+      password: bcrypt.hashSync(req.body.password, 10)
+    }
+
+    try {
+      const newUser = await User.add(user)
+
+      return res.status(201).json({
+        message: `User ${newUser} has been created`
+      })
+    }
+    catch (e) {
+      console.error(
+        `Error during ${req.method} @ ${req.path}\n\n`,
+        `Error: ${e}\n\n`
+      );
+      return res.status(500).json({ 
+        message: "We encountered an error during registration" 
+      });
+    }
+  })
+
+router.route('/login')
+  .post(async (req, res) => {
+    try {
+      const { username, password } = req.body;
+      console.log(username, password)
+      const user = await User.find({ 'u.username': username }).first()
+      console.log(user)
+      if (user && bcrypt.compareSync(password, user.password)) {
+        const token = generateToken(user);
+        console.log(token)
+        return res.status(200).json({
+          message: `Welcome ${user.username}`,
+          token
+        })
+      }
+
+      return res.status(401).json({
+        message: 'Invalid credentials'
+      })
+    }
+    catch (e) {
+      console.error(e);
+      return res
+        .status(500)
+        .json({ message: "We encountered an error while logging you in" });
+    }
+  })
+
+module.exports = router

--- a/helpers/README.md
+++ b/helpers/README.md
@@ -1,4 +1,0 @@
-# Helpers
-This folder is for functions that you find yourself using across your project. Examples: string formatters, custom array functions, etc.
-
-You can (and _should_) delete this file once you start developing your app.

--- a/helpers/jwt.js
+++ b/helpers/jwt.js
@@ -1,0 +1,17 @@
+const jwt = require("jsonwebtoken");
+
+exports.generateToken = ({ id, audit_id, username, is_admin, school }) => {
+  const payload = {
+    subject: id,
+    audit_id,
+    username,
+    is_admin,
+    school
+  };
+  const secret = process.env.JWT_SECRET;
+  const options = {
+    expiresIn: "1d"
+  };
+
+  return jwt.sign(payload, secret, options);
+};

--- a/index.js
+++ b/index.js
@@ -1,0 +1,36 @@
+// Load .env file and add environment variables
+require("dotenv").config();
+
+const express = require("express");
+const cors = require("cors");
+const morgan = require("morgan");
+const helmet = require("helmet");
+
+// Middleware & Helpers
+const { checkToken } =  require('./middlewares/authorization');
+
+// Models
+const authRoutes = require('./controllers/auth');
+
+const app = express();
+
+app.use(cors());
+app.use(express.json());
+app.use(helmet());
+app.use(morgan("dev"));
+
+// Routers:
+app.use('/api/auth', authRoutes);
+
+// Server Up
+app.get("/", (req, res) => {
+  res.status(200).json({ message: "Server is up" });
+});
+
+if (require.main == module) {
+  app.listen(process.env.PORT, () => {
+    console.log(`Dev server is up @ http://localhost:${process.env.PORT}/`);
+  });
+} else {
+  module.exports = app;
+}

--- a/knexfile.js
+++ b/knexfile.js
@@ -19,10 +19,12 @@ module.exports = {
   },
   production: {
     client: 'postgresql',
-    connection: {
-      database: process.env.PROD_DB,
-      user: process.env.PROD_USER,
-      password: process.env.PROD_PW,
+    connection: process.env.DATABASE_URL,
+    migrations: {
+      directory: './models/migrations'
+    },
+    seeds: {
+      directory: './models/seeds'
     }
   }
 };

--- a/middlewares/README.md
+++ b/middlewares/README.md
@@ -1,5 +1,0 @@
-# Middlewares
-
-This folder is where you should configure your middlewares (both custom and third party).
-
-You can (and _should_) delete once you start developing your app.

--- a/middlewares/authorization.js
+++ b/middlewares/authorization.js
@@ -1,0 +1,31 @@
+const jwt = require("jsonwebtoken");
+
+exports.checkToken = (req, res, next) => {
+  const token = req.headers.authorization;
+
+  if (token) {
+    jwt.verify(token, process.env.JWT_SECRET, (error, decodedToken) => {
+      if (error) {
+        res.status(401).json({ message: "Invalid Credentials" });
+      } else {
+        res.locals.user = decodedToken;
+        next();
+      }
+    });
+  } else {
+    res.status(401).json({ message: "No token provided" });
+  }
+};
+
+exports.checkRole = (role) => {
+  return (req, res, next) => {
+    if (req.decodedJwt.role && req.decodedJwt.role.includes(role)) {
+      next();
+    }
+    else {
+      res.status(403).json({ 
+        message: "Sorry! You don't have access to that resource"
+      })
+    }
+  }
+};

--- a/models/db/user.js
+++ b/models/db/user.js
@@ -18,11 +18,12 @@ function find(filters) {
     .select(
       'u.audit_id AS audit_id',
       'u.username AS username',
+      'u.password AS password',
       'u.avatar_url AS avatar',
       'u.is_admin AS is_admin',
       's.name AS school'
     )
-    .join('school AS s', { 's.id': 'u.school_id' })
+    .join('schools AS s', { 's.id': 'u.school_id' })
     .where(filters)
 }
 

--- a/models/migrations/20190624101324_initTables.js
+++ b/models/migrations/20190624101324_initTables.js
@@ -11,6 +11,7 @@ exports.up = function(knex) {
       tbl.increments();
       tbl.uuid('audit_id').defaultTo(uuid()).notNullable()
       tbl.text('username').notNullable()
+      tbl.text('password').notNullable()
       tbl.text('avatar_url').nullable()
       tbl.integer('school_id')
          .references('id')


### PR DESCRIPTION
This pull request enables the following endpoints:

`/api/auth/register`
`/api/auth/login`

and will allow a user to securely register for Bubl and also log into the site. 

When a user is successfully logged in, we'll include a JWT in our response that should be stored in their browser's local storage. From there, we'll need that token included in every request from the client as a header named "authorization".

closes #11 
closes #4 

/cc @t-tullis @thisbenrogers 